### PR TITLE
chore(soldeer): bump [package].version to 0.1.1 for next-version release lifecycle

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-lib-hash"
-version = "0.1.0"
+version = "0.1.1"
 
 [profile.default]
 


### PR DESCRIPTION
Closes #13

## What

Bump `foundry.toml` `[package].version` from `0.1.0` to `0.1.1` — the next, in-development (unpublished) Soldeer revision.

The shared `rainix-autopublish` reusable (pinned `@main`) moved from auto-bump to the **next-version release lifecycle** (rainlanguage/rainix#264). Under it, `[package].version` must be **strictly ahead** of the latest published revision; when they are equal the publish gate fails loud on the next Solidity-content merge:

> `foundry.toml [package].version (0.1.0) is not ahead of the published revision (0.1.0) …`

This one-time bump moves the repo onto the new lifecycle; thereafter each publish self-bumps.

## Why 0.1.1

- `foundry.toml [package].version` = `0.1.0`
- Latest published `rain-lib-hash` Soldeer revision = `0.1.0` (equal → gate fails)
- Next unpublished patch = `0.1.1` (strictly ahead ✓)

Pure-library repo — no version-keyed generated artifacts (`src/generated` absent), so no `soldeer-generate-cmd:` wiring is required.

## QA evidence

Per QA-GUIDE.md §8. This is a **config-only** change to `foundry.toml [package].version`; there is no Solidity/behavioral surface introduced or altered — no function, branch, or assertion exists to mutation-test, and the compiled bytecode and existing test suite are independent of the `[package].version` string.

- **Correctness oracle (independent):** the autopublish invariant — in-dev version strictly greater than the latest published revision. Verified independently against the live Soldeer registry: latest published `rain-lib-hash` = `0.1.0`; the pre-change value `0.1.0` is *equal* (would fail the gate), and `0.1.1 > 0.1.0` satisfies strict-ahead.
- **No weakening:** no test or assertion is added, removed, or loosened; the version string does not gate any test.
- **Build:** `forge build` succeeds with the new config.
- **Scope:** single line, single file.

Ref: rainlanguage/rainix#264

Co-Authored-By: Claude <noreply@anthropic.com>
